### PR TITLE
Fix script typos and add network export

### DIFF
--- a/Server_UNIX.sh
+++ b/Server_UNIX.sh
@@ -19,7 +19,7 @@
 ##########################################################################################
 
 # 환경 설정
-LANG=Cx
+LANG=C
 LC_ALL=C
 LANGUAGE=C
 export LANG LC_ALL LANGUAGE
@@ -2909,6 +2909,25 @@ main(){
 
   echo "" >> "$RESULT_FILE"
   echo "[JSON 결과 생성] $JSON_FILE" >> "$RESULT_FILE"
+
+  # --- 네트워크 공유에 JSON 업로드 ---
+  SHARE_PATH="//192.168.100.20/Landf/정보보안부문/4.개인폴더/윤지환/Dev_unix"
+  SHARE_USER="계정"
+  SHARE_PASS="비밀번호"
+  MNT_DIR="/tmp/share_mnt"
+
+  mkdir -p "$MNT_DIR"
+  if mount -t cifs "$SHARE_PATH" "$MNT_DIR" -o username=$SHARE_USER,password=$SHARE_PASS,iocharset=utf8 2>>"$RESULT_FILE"; then
+    host_ip=$(hostname -I | awk '{print $1}')
+    folder_name="${host_ip}_${HOSTNAME}"
+    mkdir -p "$MNT_DIR/$folder_name"
+    cp "$JSON_FILE" "$MNT_DIR/$folder_name/"
+    umount "$MNT_DIR"
+    rmdir "$MNT_DIR"
+    echo "[네트워크 저장 완료] $JSON_FILE -> $SHARE_PATH/$folder_name" >> "$RESULT_FILE"
+  else
+    echo "[WARN] CIFS 공유 마운트 실패: $SHARE_PATH" >> "$RESULT_FILE"
+  fi
 }
 
 # 메인 함수 실행

--- a/test.sh
+++ b/test.sh
@@ -11,10 +11,10 @@ LANG="$lang_check"
 LC_ALL="$lang_check"
 LANGUAGE="$lang_check"
 export LANG
-export LC ALL
+export LC_ALL
 export LANGUAGE
 
-if [ "`command -v netstat 2>/dev/nul`" != "" ] || [ "`which netstat 2>/dev/null`" != "" ]; then
+if [ "`command -v netstat 2>/dev/null`" != "" ] || [ "`which netstat 2>/dev/null`" != "" ]; then
 		port_cmd="netstat"
 
 else
@@ -47,7 +47,7 @@ else
 fi
 echo "" >> $RESULT_FILE 2>&1
 
-echo "1-2. SSH Service Check" >> RESULT_FILE 2>&1
+echo "1-2. SSH Service Check" >> $RESULT_FILE 2>&1
 if [ "$systemctl_cmd" != "" ]; then
 		get_ssh_service=`$systemctl_cmd list-units --type service | egrep '(ssh|sshd)\.service' | sed -e 's/^*//g' -e 's/^	*//g' | tr -s " \t"`
 	if [ "$get_ssh_service" != "" ]; then
@@ -76,7 +76,7 @@ fi
 if [ "$get_ssh_ps" != "" ] || [ "$get_ssh_service" != "" ] || [ "$get_ssh_port" != "" ]; then
 	echo "" >> $RESULT_FILE 2>&1
 	echo "1-4. SSH Configuration File Check" >> $RESULT_FILE 2>&1
-	if [ -f "etc/ssh/sshd_config" ]; then
+        if [ -f "/etc/ssh/sshd_config" ]; then
 		get_ssh_conf=`cat /etc/ssh/sshd_config | egrep -v '^#|^$' | grep "PermitRootLogin"`
 		if [ "$get_ssh_conf" != "" ];then
 			echo "/etc/ssh/sshd_config : $get_ssh_conf" >> $RESULT_FILE 2>&1
@@ -177,7 +177,7 @@ if [ $ssh_flag -eq 1 ] && [ $telnet_flag -eq 1 ]; then
     echo "결과값 : 양호" >> $RESULT_FILE 2>&1
 elif [ $ssh_flag -eq 0 ] || [ $telnet_flag -eq 0 ]; then
     echo "결과값 : 취약" >> $RESULT_FILE 2>&1
-elif [ $ssh_flag -eq 2 ] || [ $telnet_flag -eq 2]; then
+elif [ $ssh_flag -eq 2 ] || [ $telnet_flag -eq 2 ]; then
 	echo "결과값 : 검토" >> $RESULT_FILE 2>&1
 fi
 
@@ -212,14 +212,14 @@ echo "`cat /etc/security/pwquality.conf | grep "maxclassrepeat"`" >> $RESULT_FIL
 
 echo "▶ /etc/pam.d/system-auth 파일" >> $RESULT_FILE 2>&1
 
-if [ -f "etc/pam.d/system-auth" ]; then
+if [ -f "/etc/pam.d/system-auth" ]; then
 	echo "/etc/pam.d/system-auth 파일존재" >> $RESULT_FILE 2>&1
 else
 	echo "/etc/pam.d/system-auth 파일없음" >> $RESULT_FILE 2>&1
 fi
 echo "▶ /etc/pam.d/password-auth 파일" >> $RESULT_FILE 2>&1
 
-if [ -f "etc/pam.d/password-auth" ]; then
+if [ -f "/etc/pam.d/password-auth" ]; then
         echo "/etc/pam.d/password-auth 파일존재" >> $RESULT_FILE 2>&1
 else
         echo "/etc/pam.d/password-auth 파일없음" >> $RESULT_FILE 2>&1
@@ -245,14 +245,14 @@ else
 fi
 echo "" >> $RESULT_FILE 2>&1
 echo "▶ /etc/pam.d/system-auth 파일" >> $RESULT_FILE 2>&1
-if [ -f "etc/pam.d/system-auth" ]; then
+if [ -f "/etc/pam.d/system-auth" ]; then
         echo "/etc/pam.d/system-auth 파일존재" >> $RESULT_FILE 2>&1
 else
         echo "/etc/pam.d/system-auth 파일없음" >> $RESULT_FILE 2>&1
 fi
 echo "▶ /etc/pam.d/password-auth 파일" >> $RESULT_FILE 2>&1
 
-if [ -f "etc/pam.d/password-auth" ]; then
+if [ -f "/etc/pam.d/password-auth" ]; then
         echo "/etc/pam.d/password-auth 파일존재" >> $RESULT_FILE 2>&1
 else
         echo "/etc/pam.d/password-auth 파일없음" >> $RESULT_FILE 2>&1


### PR DESCRIPTION
## Summary
- fix path checks and syntax errors in `test.sh`
- set correct LANG in `Server_UNIX.sh`
- copy generated JSON to network share in Unix server script

## Testing
- `bash -n test.sh`
- `bash -n Server_UNIX.sh`
- `bash test.sh >/tmp/test_output.txt`

------
https://chatgpt.com/codex/tasks/task_e_687bcd60f7608321aea9f7547ade0cc7