### PR TITLE
Fix JSON logging for Unix scanner

### DIFF
--- a/unix.sh
+++ b/unix.sh
@@ -861,6 +861,7 @@ U12_services_file_perm(){
 
 # U-13: 불필요한 SUID/SGID 파일 점검 (오탐 예외 목록 추가 버전)
 U13_suid_sgid_check(){
+  start_check "U-13" "불필요한 SUID/SGID 파일 점검"
   log_info "[ U-13 ] : 불필요한 SUID/SGID 파일 점검"
   log_info "[ U-13 SUID/SGID 설정 파일 점검 START]"
   log_info ""
@@ -1001,7 +1002,6 @@ U13_suid_sgid_check(){
   fi
 
   echo "==================== [U-13 END]" >> "$RESULT_FILE"
-  log_info ""
 }
 
 
@@ -1173,7 +1173,6 @@ U18_ip_port_restriction(){
       print_result "U-18" "검토"
       ;;
   esac
-  log_info ""
 }
 
 # U-19: Finger 서비스 비활성화 (고도화)
@@ -1260,7 +1259,6 @@ U19_finger_disable(){
       fi
       ;;
   esac
-  log_info ""
 }
 
 # U-20: Anonymous FTP 비활성화 (고도화)


### PR DESCRIPTION
## Summary
- ensure `U13_suid_sgid_check` initializes with `start_check`
- remove stray `log_info ""` calls after printing results to avoid empty `CURRENT_ID`

## Testing
- `bash unix.sh >/tmp/unix_run4.log && tail -n 20 /tmp/unix_run4.log`

------
https://chatgpt.com/codex/tasks/task_e_687be95a2010832198ecf22c4091f934