### PR TITLE
Fix JSON logging for Unix scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,11 @@ Blank lines between sections are written without the `[INFO]` prefix so that
 all informational content is grouped between the `[INFO]` header and the
 `[RESULT]` line.
 
+`unix.sh` also writes its results to the `Results` directory. The script first
+tries to send the JSON file using `smbclient`. If that tool is not available you
+can set the `SCP_TARGET` variable (for example `user@192.168.0.10:/dest`) and
+the file will be uploaded via `scp` instead. When no transfer method is
+available the location of the JSON file is shown for manual retrieval.
+
 ![image](https://github.com/user-attachments/assets/4717d879-4098-4aad-b8eb-1237efc06c2c)
 ![image](https://github.com/user-attachments/assets/dd27a027-ab44-49ec-855f-df2e10a12436)

--- a/unix.sh
+++ b/unix.sh
@@ -32,6 +32,8 @@ SHARE_NAME="Landf/정보보안부문/4.개인폴더/윤지환/Dev_unix"
 # 2. 서버 접속 계정 정보
 SHARE_USER="계정"
 SHARE_PASS="비밀번호"
+# (선택) scp 전송 대상 경로(예: "user@192.168.100.20:/path")
+: "${SCP_TARGET:=}"
 # --- 설정 종료 ---
 
 HOSTNAME=$(hostname)
@@ -185,6 +187,35 @@ send_json_with_smbclient() {
     else
         echo "[ERROR] 파일 전송 실패. 상세 내용은 $RESULT_FILE 파일을 확인하세요."
     fi
+}
+
+send_json_with_scp() {
+    if [ -z "$SCP_TARGET" ]; then
+        return 1
+    fi
+    if ! command -v scp >/dev/null; then
+        return 1
+    fi
+    echo "[INFO] scp를 이용해 결과 전송을 시도합니다..." | tee -a "$RESULT_FILE"
+    scp -q "$JSON_FILE" "$SCP_TARGET" >> "$RESULT_FILE" 2>&1
+    if [ $? -eq 0 ]; then
+        echo "[INFO] scp 전송 성공: $SCP_TARGET" | tee -a "$RESULT_FILE"
+        return 0
+    else
+        echo "[ERROR] scp 전송 실패" | tee -a "$RESULT_FILE"
+        return 1
+    fi
+}
+
+send_json(){
+    if command -v smbclient >/dev/null; then
+        send_json_with_smbclient && return
+    fi
+
+    send_json_with_scp && return
+
+    echo "[WARN] 사용할 수 있는 전송 방법이 없어 자동 전송을 건너뜁니다." | tee -a "$RESULT_FILE"
+    echo "[INFO] 수동 전송이 필요합니다: $JSON_FILE" | tee -a "$RESULT_FILE"
 }
 
 # (1-2) 숫자 판별 함수
@@ -861,6 +892,7 @@ U12_services_file_perm(){
 
 # U-13: 불필요한 SUID/SGID 파일 점검 (오탐 예외 목록 추가 버전)
 U13_suid_sgid_check(){
+  start_check "U-13" "불필요한 SUID/SGID 파일 점검"
   log_info "[ U-13 ] : 불필요한 SUID/SGID 파일 점검"
   log_info "[ U-13 SUID/SGID 설정 파일 점검 START]"
   log_info ""
@@ -1001,7 +1033,6 @@ U13_suid_sgid_check(){
   fi
 
   echo "==================== [U-13 END]" >> "$RESULT_FILE"
-  log_info ""
 }
 
 
@@ -1173,7 +1204,6 @@ U18_ip_port_restriction(){
       print_result "U-18" "검토"
       ;;
   esac
-  log_info ""
 }
 
 # U-19: Finger 서비스 비활성화 (고도화)
@@ -1260,7 +1290,6 @@ U19_finger_disable(){
       fi
       ;;
   esac
-  log_info ""
 }
 
 # U-20: Anonymous FTP 비활성화 (고도화)
@@ -2864,7 +2893,7 @@ main(){
 
     # 2. 생성된 JSON 파일을 서버로 전송
     if [ -f "$JSON_FILE" ]; then
-        send_json_with_smbclient
+        send_json
     else
         echo "[ERROR] JSON 파일이 생성되지 않아 서버로 전송할 수 없습니다." >> "$RESULT_FILE"
     fi


### PR DESCRIPTION
## Summary
- ensure `U13_suid_sgid_check` initializes with `start_check`
- remove stray `log_info ""` calls after printing results to avoid empty `CURRENT_ID`
- add optional SCP fallback for JSON uploads
- document SCP upload option in README

## Testing
- `bash -n unix.sh`
- `SCP_TARGET="localhost:/tmp" bash unix.sh >/tmp/unix_run4.log && tail -n 20 /tmp/unix_run4.log`

------
https://chatgpt.com/codex/tasks/task_e_687be95a2010832198ecf22c4091f934