### PR TITLE
Add CIFS mount upload method

### DIFF
--- a/unix2.sh
+++ b/unix2.sh
@@ -189,6 +189,26 @@ send_json_with_smbclient() {
     fi
 }
 
+send_json_with_cifs() {
+    local share_path="//${SHARE_SERVER}/${SHARE_NAME}"
+    local mnt_dir="${TMP_DIR}/share_mnt"
+    mkdir -p "$mnt_dir"
+
+    if mount -t cifs "$share_path" "$mnt_dir" -o username=$SHARE_USER,password=$SHARE_PASS,iocharset=utf8 >> "$RESULT_FILE" 2>&1; then
+        local folder_name="${IP_ADDR}_${HOSTNAME}"
+        mkdir -p "$mnt_dir/$folder_name"
+        cp "$JSON_FILE" "$mnt_dir/$folder_name/"
+        umount "$mnt_dir"
+        rmdir "$mnt_dir"
+        echo "[INFO] 파일 전송 성공: ${share_path}/$folder_name" | tee -a "$RESULT_FILE"
+        return 0
+    else
+        echo "[WARN] CIFS 공유 마운트 실패: $share_path" | tee -a "$RESULT_FILE"
+        rmdir "$mnt_dir"
+        return 1
+    fi
+}
+
 send_json_with_scp() {
     if [ -z "$SCP_TARGET" ]; then
         return 1
@@ -208,6 +228,8 @@ send_json_with_scp() {
 }
 
 send_json(){
+    send_json_with_cifs && return
+
     if command -v smbclient >/dev/null; then
         send_json_with_smbclient && return
     fi


### PR DESCRIPTION
## Summary
- add `send_json_with_cifs` for mounting network shares directly
- call the new function from `send_json` before other upload methods

## Testing
- `shellcheck unix2.sh`
- `bash -n unix2.sh`


------
https://chatgpt.com/codex/tasks/task_e_687bf5d828108321af7a8858e675131d