### PR TITLE
Improve process checks in Unix scanner

### DIFF
--- a/Linux_Server_Auto_dev.sh
+++ b/Linux_Server_Auto_dev.sh
@@ -411,7 +411,7 @@ U01_root_remote_login(){
   local ssh_flag=1
 
   # Telnet 프로세스와 /etc/securetty 점검 (Telnet 사용 시)
-  if ps -ef | grep -v grep | grep -q "[t]elnetd"; then
+  if pgrep -x telnetd >/dev/null 2>&1; then
     log_info "Telnet 프로세스 구동"
     if [ -f /etc/securetty ]; then
       local pts_check
@@ -435,7 +435,7 @@ U01_root_remote_login(){
     log_info "SSH 프로세스 동작"
     if [ -f /etc/ssh/sshd_config ]; then
       local pr
-      pr=$(grep -i '^PermitRootLogin' /etc/ssh/sshd_config | grep -v '^#' | awk '{print $2}')
+      pr=$(awk '!/^[[:space:]]*#/ && tolower($1)=="permitrootlogin" {print tolower($2); exit}' /etc/ssh/sshd_config)
       if [ "$pr" = "no" ]; then
         log_info "SSH PermitRootLogin no → 양호"
       else
@@ -1273,7 +1273,7 @@ U19_finger_disable(){
             print_result "U-19" "양호"
           fi
         else
-          if ps -ef | grep -v grep | grep -q "[f]ingerd"; then
+          if pgrep -x fingerd >/dev/null 2>&1; then
             log_info "Linux fingerd 프로세스 존재(취약)"
             print_result "U-19" "취약"
           else
@@ -1282,7 +1282,7 @@ U19_finger_disable(){
           fi
         fi
       else
-        if ps -ef | grep -v grep | egrep -iq 'in.rshd|in.rlogind|in.rexecd'; then
+        if pgrep -f 'in.rshd|in.rlogind|in.rexecd' >/dev/null 2>&1; then
           log_info "Unknown OS, r-command 프로세스 발견(검토)"
           print_result "U-19" "검토"
         else
@@ -1303,7 +1303,7 @@ U19_finger_disable(){
       fi
       ;;
     *)
-      if ps -ef | grep -v grep | grep -q "[f]ingerd"; then
+      if pgrep -x fingerd >/dev/null 2>&1; then
         log_info "Unknown OS, finger 프로세스 존재(취약)"
         print_result "U-19" "취약"
       else
@@ -1319,9 +1319,10 @@ U20_anonymous_ftp(){
   start_check "U-20" "Anonymous FTP 비활성화"
 
   local ftp_running=0
-  local ftp_procs
-  ftp_procs=$(ps -ef | grep -v grep | egrep 'vsftpd|proftpd|pure-ftpd|ftpd')
-  if [ -n "$ftp_procs" ]; then
+  if pgrep -f vsftpd >/dev/null 2>&1 || \
+     pgrep -f proftpd >/dev/null 2>&1 || \
+     pgrep -f pure-ftpd >/dev/null 2>&1 || \
+     pgrep -x ftpd >/dev/null 2>&1; then
     ftp_running=1
   fi
 
@@ -1471,7 +1472,7 @@ U21_r_command_disable(){
       fi
       ;;
     *)
-      if ps -ef | grep -v grep | egrep -iq 'in.rshd|in.rlogind|in.rexecd'; then
+      if pgrep -f 'in.rshd|in.rlogind|in.rexecd' >/dev/null 2>&1; then
         log_info "Unknown OS r계열 서비스 프로세스 발견(취약)"
         found=1
       fi
@@ -1583,7 +1584,7 @@ U24_nfs_disable(){
   start_check "U-24" "NFS 서비스 비활성화"
 
   local nfs_ps
-  nfs_ps=$(ps -ef | grep -E '\b(rpc\.?nfsd|rpc\.?mountd|rpc\.?statd|rpc\.?lockd|nfsd|mountd|statd|lockd)\b' | grep -v grep)
+  nfs_ps=$(pgrep -f 'rpc\.nfsd|rpc\.mountd|rpc\.statd|rpc\.lockd|nfsd|mountd|statd|lockd')
   if [ -n "$nfs_ps" ]; then
     log_info "NFS 관련 데몬 동작 중(취약):"
     log_info "$nfs_ps"
@@ -1621,7 +1622,7 @@ U26_automountd_remove(){
   start_check "U-26" "automountd(autofs) 제거"
 
   local psres
-  psres=$(ps -ef | grep -v grep | grep -E 'automount|autofs')
+  psres=$(pgrep -f 'automount|autofs')
   if [ -n "$psres" ]; then
     log_info "automountd(autofs) 동작 중(취약)"
     print_result "U-26" "취약"
@@ -1637,7 +1638,7 @@ U27_rpc_service_check(){
 
   local rpclist="rpc.cmsd|rpc.ttdbserverd|rpc.rusersd|rpc.rwalld|rpc.sprayd|rpc.nisd|rpc.rexecd|rpc.pcnfsd|rpc.statd|rpc.lockd|rpc.ypupdated|sadmind|cachefsd"
   local psres
-  psres=$(ps -ef | grep -v grep | egrep "$rpclist")
+  psres=$(pgrep -f "$rpclist")
   if [ -n "$psres" ]; then
     log_info "불필요한 RPC 서비스 동작 중(취약):"
     log_info "$psres"
@@ -1653,7 +1654,7 @@ U28_nis_check(){
   start_check "U-28" "NIS, NIS+ 점검"
 
   local psres
-  psres=$(ps -ef | grep -v grep | egrep 'ypserv|ypbind|ypxfrd|rpc.yppasswdd|rpc.ypupdated')
+  psres=$(pgrep -f 'ypserv|ypbind|ypxfrd|rpc.yppasswdd|rpc.ypupdated')
   if [ -n "$psres" ]; then
     log_info "NIS(YP) 서비스 동작(취약)"
     print_result "U-28" "취약"
@@ -1699,7 +1700,7 @@ U30_sendmail_version(){
   start_check "U-30" "Sendmail 버전 점검"
 
   local sm_ps
-  sm_ps=$(ps -ef | grep -v grep | grep sendmail)
+  sm_ps=$(pgrep -x sendmail)
   if [ -n "$sm_ps" ]; then
     log_info "Sendmail 동작 → 버전 확인 및 패치 권고(검토)"
     print_result "U-30" "검토"
@@ -1714,7 +1715,7 @@ U31_spam_mail_relay(){
   start_check "U-31" "스팸 메일 릴레이 제한"
 
   local sm_ps
-  sm_ps=$(ps -ef | grep -v grep | grep sendmail)
+  sm_ps=$(pgrep -x sendmail)
   if [ -n "$sm_ps" ]; then
     if [ -f /etc/mail/sendmail.cf ]; then
       local rel
@@ -1741,7 +1742,7 @@ U32_sendmail_restrictqrun(){
   start_check "U-32" "일반사용자의 Sendmail 실행 방지 (restrictqrun)"
 
   local sm_ps
-  sm_ps=$(ps -ef | grep -v grep | grep sendmail)
+  sm_ps=$(pgrep -x sendmail)
   if [ -n "$sm_ps" ]; then
     if [ -f /etc/mail/sendmail.cf ]; then
       local prline
@@ -1768,7 +1769,7 @@ U33_dns_security_patch(){
   start_check "U-33" "DNS 보안 버전 패치"
 
   local named_ps
-  named_ps=$(ps -ef | grep -v grep | grep named)
+  named_ps=$(pgrep -x named)
   if [ -n "$named_ps" ]; then
     log_info "DNS(named) 동작 중 → 최신 보안 패치 적용 필요(검토)"
     print_result "U-33" "검토"
@@ -1783,7 +1784,7 @@ U34_dns_zone_transfer(){
   start_check "U-34" "DNS Zone Transfer 설정"
 
   local named_ps
-  named_ps=$(ps -ef | grep -v grep | grep named)
+  named_ps=$(pgrep -x named)
   if [ -z "$named_ps" ]; then
     log_info "DNS 미사용(양호)"
     print_result "U-34" "양호"
@@ -2548,7 +2549,7 @@ U59_hidden_file_check(){
 U60_ssh_usage(){
   start_check "U-60" "SSH 원격접속 사용 여부"
 
-  if ps -ef | grep -v grep | grep -q "[s]shd"; then
+  if pgrep -x sshd >/dev/null 2>&1; then
     log_info "SSH 서비스 동작 중(양호)"
     print_result "U-60" "양호"
   else
@@ -2561,7 +2562,10 @@ U60_ssh_usage(){
 U61_ftp_service(){
   start_check "U-61" "FTP 서비스 확인"
 
-  if ps -ef | grep -v grep | egrep -q 'vsftpd|proftpd|pure-ftpd|ftpd'; then
+  if pgrep -f vsftpd >/dev/null 2>&1 || \
+     pgrep -f proftpd >/dev/null 2>&1 || \
+     pgrep -f pure-ftpd >/dev/null 2>&1 || \
+     pgrep -x ftpd >/dev/null 2>&1; then
     log_info "FTP 서비스 동작 중(검토)"
     print_result "U-61" "검토"
   else
@@ -2656,7 +2660,7 @@ U64_ftpusers_setting(){
   fi
 
   local rootline
-  rootline=$(grep -E '^root$' "$tfile")
+  rootline=$(grep -Fx 'root' "$tfile")
   if [ -n "$rootline" ]; then
     log_info "ftpusers 파일에 root 계정 등록됨(양호)"
     print_result "U-64" "양호"
@@ -2696,7 +2700,7 @@ U65_at_perm(){
 U66_snmp_service_check(){
   start_check "U-66" "SNMP 서비스 구동 점검"
 
-  if ps -ef | grep -v grep | grep -q "[s]nmpd"; then
+  if pgrep -x snmpd >/dev/null 2>&1; then
     log_info "SNMP 데몬 동작 중(검토)"
     print_result "U-66" "검토"
   else
@@ -2796,7 +2800,7 @@ U70_expn_vrfy_disable(){
   start_check "U-70" "expn, vrfy 명령어 제한"
 
   local sm_ps
-  sm_ps=$(ps -ef | grep -v grep | grep sendmail)
+  sm_ps=$(pgrep -x sendmail)
   if [ -n "$sm_ps" ]; then
     if [ -f /etc/mail/sendmail.cf ]; then
       local pr


### PR DESCRIPTION
## Summary
- switch SSH PermitRootLogin parsing to awk for accurate case handling
- replace remaining `grep -v grep` patterns with `pgrep`
- refine ftp, RPC, and sendmail process detection

## Testing
- `bash -n Linux_Server_Auto_dev.sh`


------
https://chatgpt.com/codex/tasks/task_e_687bfb1079c88321a0bea93f5c0859d8